### PR TITLE
check members first, only add new emails, cleanup reqs/doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,6 @@ MailChimp API: I couldn't find any numbers from their documentation [here](https
 
 2. Locally running `dev_appserver.py` will not allow you to run the job without mocking the KMS/GCS calls. I am sure you could open up the ACLs/settings a bit further but this is unexplored at this time.
 
-3. All users are attempted to be loaded into the MailChimp list. The MailChimp API throws a 400 with the `mailchimp3` library used in the way that it is (maybe there is a better way?). The current members could be pulled first to not make this call and receive the error. Generically, all HTTP Errors are caught which is not ideal. This can certainly be improved.
-
-4. There is no special logic for users with the same email address. The email is used as a key for the cleaned-up data.
-
 ## Pull Requests
 
 Sure, but please give me some time.

--- a/project/app.yaml
+++ b/project/app.yaml
@@ -14,6 +14,11 @@ libraries:
 - name: ssl
   version: latest
 
+# In my case, I am using a F2.
+# Feel free to tune as needed.
+# Doc: https://cloud.google.com/appengine/docs/standard/
+instance_class: F2
+
 resources:
   cpu: 1
   memory_gb: 0.5
@@ -21,3 +26,4 @@ resources:
 
 env_variables:
   PYTHONHTTPSVERIFY: 1
+  GAE_USE_SOCKETS_HTTPLIB : 'puppies!'

--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -1,6 +1,5 @@
 Flask==0.12.2
-google-cloud==0.30.0
+google-cloud==0.31.0
 google-api-python-client==1.6.4
 mailchimp3==2.0.18
-requests[security]==2.18.4
-urllib3[secure]==1.22
+requests==2.18.4


### PR DESCRIPTION
- Optimizes (should have never done it this way) by getting all of the MailChimp list members *first* before trying to create new members.  Reduces the number of calls to MailChimp from one per member to one for the list, and one for each new member.  No more 400s to MailChimp (sorry about that!).
- Adds an updated `instance_class` and sockets lib by default.  Feel free to remove but this is what I am using for larger list processing at the moment.
- Version bumps.